### PR TITLE
Add top-10 genre filtering for moderation analysis

### DIFF
--- a/src/analysis/analysis.R
+++ b/src/analysis/analysis.R
@@ -8,10 +8,12 @@ library(ggplot2)
 library(broom)
 
 # -----------------------------------------
-# 1) Read cleaned data from gen/temp
+# 1) Read filtered data from gen/temp
 # -----------------------------------------
-IMDB_movies <- read_csv("../../gen/temp/imdb_movies.csv")
-IMDB_long   <- read_csv("../../gen/temp/imdb_long.csv")
+IMDB_filtered <- read_csv("../../gen/temp/imdb_filtered.csv")
+
+# Convert top_genre to a factor for regression
+IMDB_filtered$top_genre <- as.factor(IMDB_filtered$top_genre)
 
 # -----------------------------------------
 # 2) Create output directory & open PDF
@@ -22,7 +24,7 @@ pdf("../../gen/output/analysis_report.pdf", width = 10, height = 7)
 # -----------------------------------------
 # 3) Create mean-centered runtime variable
 # -----------------------------------------
-IMDB_movies <- IMDB_movies %>%
+IMDB_filtered <- IMDB_filtered %>%
   mutate(m_runtime = runtimeMinutes - mean(runtimeMinutes, na.rm = TRUE))
 
 # -------------------------
@@ -30,7 +32,7 @@ IMDB_movies <- IMDB_movies %>%
 # -------------------------
 
 # (A) Overall linearity: scatter + linear fit
-ggplot(IMDB_movies, aes(x = runtimeMinutes, y = averageRating)) +
+ggplot(IMDB_filtered, aes(x = runtimeMinutes, y = averageRating)) +
   geom_point(alpha = 0.05) +
   geom_smooth(method = "lm", se = TRUE) +
   labs(
@@ -40,14 +42,14 @@ ggplot(IMDB_movies, aes(x = runtimeMinutes, y = averageRating)) +
   )
 
 # (B) By-genre linearity
-ggplot(IMDB_long, aes(x = runtimeMinutes, y = averageRating)) +
+ggplot(IMDB_filtered, aes(x = runtimeMinutes, y = averageRating, color = top_genre)) +
   geom_point(alpha = 0.03) +
   geom_smooth(method = "lm", se = FALSE) +
-  facet_wrap(~ genre) +
+  facet_wrap(~ top_genre) +
   labs(
     x = "Runtime (minutes)",
     y = "Average rating",
-    title = "Runtime vs Average Rating by Genre"
+    title = "Runtime vs Average Rating by Top Genre"
   )
 
 # -------------------------
@@ -55,33 +57,15 @@ ggplot(IMDB_long, aes(x = runtimeMinutes, y = averageRating)) +
 # -------------------------
 
 # Model 1: Runtime only
-lm1 <- lm(averageRating ~ m_runtime, data = IMDB_movies)
+lm1 <- lm(averageRating ~ m_runtime, data = IMDB_filtered)
 summary(lm1)
 
-# Model 2: Runtime + genres
-lm2 <- lm(averageRating ~ m_runtime +
-    genre_Drama + genre_Comedy + genre_Romance + genre_Action +
-    genre_Thriller + genre_Crime + genre_Horror + genre_Documentary +
-    genre_Adventure + genre_Mystery + genre_Family + genre_Fantasy +
-    genre_Biography + `genre_Sci-Fi` + genre_History + genre_Music +
-    genre_Animation + genre_War + genre_Musical +
-    genre_Sport + genre_Western,
-  data = IMDB_movies
-)
+# Model 2: Runtime + top_genre (main effects only)
+lm2 <- lm(averageRating ~ m_runtime + top_genre, data = IMDB_filtered)
 summary(lm2)
 
-# Model 3: Runtime × genres (includes main effects + interactions)
-lm3 <- lm(
-  averageRating ~ m_runtime * (
-    genre_Drama + genre_Comedy + genre_Romance + genre_Action +
-      genre_Thriller + genre_Crime + genre_Horror + genre_Documentary +
-      genre_Adventure + genre_Mystery + genre_Family + genre_Fantasy +
-      genre_Biography + `genre_Sci-Fi` + genre_History + genre_Music +
-      genre_Animation + genre_War + genre_Musical +
-      genre_Sport + genre_Western
-  ),
-  data = IMDB_movies
-)
+# Model 3: Runtime × top_genre (main effects + interaction)
+lm3 <- lm(averageRating ~ m_runtime * top_genre, data = IMDB_filtered)
 summary(lm3)
 
 # Model comparison - ANOVA as text on PDF page
@@ -93,11 +77,11 @@ text(0.05, 0.85, paste(capture.output(anova_result), collapse = "\n"),
 
 # Compact table of runtime + runtime×genre terms from lm3
 interaction_terms <- tidy(lm3, conf.int = TRUE) %>%
-  filter(term == "m_runtime" | str_detect(term, "^m_runtime:genre_")) %>%
+  filter(term == "m_runtime" | str_detect(term, "^m_runtime:top_genre")) %>%
   arrange(desc(abs(estimate)))
 
 plot.new()
-title(main = "Runtime x Genre Interaction Terms (Model 3)", cex.main = 1.3)
+title(main = "Runtime x Top Genre Interaction Terms (Model 3)", cex.main = 1.3)
 text(0.05, 0.85, paste(capture.output(print(interaction_terms, n = Inf)), collapse = "\n"),
      family = "mono", adj = c(0, 1), cex = 0.5)
 

--- a/src/analysis/makefile
+++ b/src/analysis/makefile
@@ -6,6 +6,6 @@ OUTPUT = ../../gen/output
 all: $(OUTPUT)/analysis_report.pdf
 
 #Step 1: analysis
-$(OUTPUT)/analysis_report.pdf: analysis.R $(TEMP)/imdb_movies.csv $(TEMP)/imdb_long.csv
+$(OUTPUT)/analysis_report.pdf: analysis.R $(TEMP)/imdb_filtered.csv
 		R -e "dir.create('$(OUTPUT)', recursive=TRUE)"
 		Rscript analysis.R

--- a/src/data-preparation/data-cleaning.R
+++ b/src/data-preparation/data-cleaning.R
@@ -34,53 +34,36 @@ IMDB_movies <- IMDB_movies %>%
          numVotes > 100) %>%
   select(-titleType, -isAdult, -startYear, -endYear)
 
-# Splitting genres
-IMDB_movies <- IMDB_movies %>% 
-  separate_rows(genres, sep = ",") %>% 
-  mutate(value = 1) %>% 
-  pivot_wider(names_from = genres,
-              values_from = value,
-              values_fill = 0,
-              names_prefix = "genre_")
+# Step 1: Split genres into individual rows for counting
+genre_split <- IMDB_movies %>%
+  select(tconst, genres) %>%
+  separate_rows(genres, sep = ",")
 
-#Identifying genres and counting frequency of each genre
-genre_cols <- grep("^genre_", names(IMDB_movies), value = TRUE)
+# Step 2: Identify the top 10 most frequent genres
+top10_genres <- genre_split %>%
+  count(genres, sort = TRUE) %>%
+  slice_head(n = 10) %>%
+  pull(genres)
 
-genre_frequency <- sort(colSums(IMDB_movies[genre_cols]), decreasing = TRUE)
+cat("Top 10 genres:\n")
+print(top10_genres)
 
-genre_frequency
-
-# % of frequency of each genre
-genre_percentage <- genre_frequency / nrow(IMDB_movies) * 100
-
-genre_percentage <- round(genre_percentage, 1)
-
-genre_percentage
-
-
-# Removing genres with frequency < 1%
-
-genres_to_remove <- names(genre_percentage[genre_percentage < 1])
-genres_to_remove
-
-IMDB_movies <- IMDB_movies %>%
-  select(-all_of(genres_to_remove))
-
-
-# # Identify remaining genre columns
-genre_cols_kept <- grep("^genre_", names(IMDB_movies), value = TRUE)
-
-# Convert to long format for plotting
-IMDB_long <- IMDB_movies %>%
-  pivot_longer(
-    cols = all_of(genre_cols_kept),
-    names_to = "genre",
-    values_to = "has_genre"
+# Step 3 & 4: For each movie, count how many of its genres are in the top 10.
+#              Keep only movies where exactly 1 genre is in the top 10.
+IMDB_filtered <- IMDB_movies %>%
+  mutate(
+    top_genres_list = map(str_split(genres, ","), ~ intersect(.x, top10_genres)),
+    n_top = map_int(top_genres_list, length)
   ) %>%
-  filter(has_genre == 1) %>%
-  mutate(genre = str_remove(genre, "^genre_"))
+  filter(n_top == 1)
 
+cat("Movies with exactly 1 top-10 genre:", nrow(IMDB_filtered), "\n")
 
-write_csv(IMDB_long, "../../gen/temp/imdb_long.csv")
-write_csv(IMDB_movies, "../../gen/temp/imdb_movies.csv")
+# Step 5: Create the top_genre column and clean up helper columns
+IMDB_filtered <- IMDB_filtered %>%
+  mutate(top_genre = map_chr(top_genres_list, 1)) %>%
+  select(-top_genres_list, -n_top)
+
+# Write filtered dataset
+write_csv(IMDB_filtered, "../../gen/temp/imdb_filtered.csv")
 

--- a/src/data-preparation/makefile
+++ b/src/data-preparation/makefile
@@ -3,7 +3,7 @@ DATA = ../../data/raw
 TEMP = ../../gen/temp
 
 #Phony target to make everything in this makefile
-all: $(TEMP)/imdb_long.csv $(TEMP)/imdb_movies.csv
+all: $(TEMP)/imdb_filtered.csv
 
 
 #Step 1: download
@@ -11,8 +11,8 @@ $(DATA)/title.basics.tsv.gz $(DATA)/title.ratings.tsv.gz: download-data.R
 		R -e "dir.create('$(DATA)', recursive = TRUE)"
 		Rscript download-data.R
 
-#Step 2: clean data
-$(TEMP)/imdb_long.csv $(TEMP)/imdb_movies.csv: data-cleaning.R $(DATA)/title.basics.tsv.gz $(DATA)/title.ratings.tsv.gz
+#Step 2: clean and filter data
+$(TEMP)/imdb_filtered.csv: data-cleaning.R $(DATA)/title.basics.tsv.gz $(DATA)/title.ratings.tsv.gz
 		R -e "dir.create('$(TEMP)', recursive=TRUE)"
 		Rscript data-cleaning.R
 		


### PR DESCRIPTION
## Summary
- Filter movies to keep only those with exactly 1 top-10 genre, creating a `top_genre` column
- Update analysis to regress rating on runtime with `top_genre` as a moderator (interaction effect)
- Update makefiles to reflect new input/output file names

## Test plan
- [ ] Run `make clean && make` to verify the full pipeline runs end-to-end
- [ ] Check that `gen/temp/imdb_filtered.csv` contains the `top_genre` column
- [ ] Verify `gen/output/analysis_report.pdf` includes all plots and model summaries